### PR TITLE
Add Ignore method specifying param name as string

### DIFF
--- a/src/TypeMerger.Tests/TypeMergerTests.cs
+++ b/src/TypeMerger.Tests/TypeMergerTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Xunit;
 using FluentAssertions;
 using System.Collections.Generic;
@@ -49,6 +49,22 @@ namespace TypeMerger.Tests {
 
             var result = TypeMerger.Ignore(() => obj1.Property1)
                                    .Ignore(() => obj2.Property4)
+                                   .Merge(obj1, obj2);
+
+            result.GetType().GetProperties().Length.Should().Be(2);
+            result.GetType().GetProperty("Property1").GetValue(result).Should().Be("value2");
+            result.GetType().GetProperty("Property2").Should().NotBeNull();
+
+        }
+
+        [Fact]
+        public void Merge_Types_with_Ignore_Policy_By_Name() {
+
+            var obj1 = new { Property1 = "value1", Property2 = "value1" };
+            var obj2 = new { Property1 = "value2", Property4 = "value4" };
+
+            var result = TypeMerger.Ignore(obj1, nameof(obj1.Property1))
+                                   .Ignore(obj2, nameof(obj2.Property4))
                                    .Merge(obj1, obj2);
 
             result.GetType().GetProperties().Length.Should().Be(2);

--- a/src/TypeMerger/TypeMerger.cs
+++ b/src/TypeMerger/TypeMerger.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Reflection.Emit;
@@ -87,6 +87,15 @@ namespace TypeMerger {
         /// <returns>TypeMerger policy used in method chaining.</returns>
         public static TypeMergerPolicy Ignore(Expression<Func<object>> ignoreProperty) {
             return new TypeMergerPolicy().Ignore(ignoreProperty);
+        }
+
+        /// <summary>
+        /// Specify a property to be ignored from a object being merged.
+        /// </summary>
+        /// <param name="ignoreProperty">The property of the object to be ignored as a String.</param>
+        /// <returns>TypeMerger policy used in method chaining.</returns>
+        public static TypeMergerPolicy Ignore<T>(T instance, string ignoreProperty) {
+            return new TypeMergerPolicy().Ignore(instance, ignoreProperty);
         }
 
         /// <summary>

--- a/src/TypeMerger/TypeMergerPolicy.cs
+++ b/src/TypeMerger/TypeMergerPolicy.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
 
@@ -37,6 +37,17 @@ namespace TypeMerger {
         public TypeMergerPolicy Ignore(Expression<Func<object>> ignoreProperty) {
 
             ignoredProperties.Add(GetObjectTypeAndProperty(ignoreProperty));
+            return this;
+        }
+
+        /// <summary>
+        /// Specify a property to be ignored from a object being merged.
+        /// </summary>
+        /// <param name="instance">The object instance</param>
+        /// <param name="ignoreProperty">The property of the object to be ignored as a Func.</param>
+        /// <returns>TypeMerger policy used in method chaining.</returns>
+        public TypeMergerPolicy Ignore<T>(T instance, string ignoreProperty) {
+            ignoredProperties.Add(new Tuple<string, string>(instance.GetType().Name, ignoreProperty));
             return this;
         }
 
@@ -89,5 +100,7 @@ namespace TypeMerger {
 
             return new Tuple<string, string>(objType, propName);
         }
+
+        
     }
 }


### PR DESCRIPTION
Hi, I've been using your library and found it useful. I recently came across a case where I couldn't use the expression-based Ignore function - in EFCore lazy loaded entities, a proxy class is created at runtime, and a property "LazyLoader" is added. Since this is not visible at compile time, I can't remove it via expression, when merging with another class.